### PR TITLE
Fix roll check

### DIFF
--- a/src/generala.py
+++ b/src/generala.py
@@ -125,7 +125,7 @@ class GeneralaGame:
         self.roll_number = 1
 
     def roll(self, held: Optional[List[int]] = None):
-        if self.roll_number > GeneralaRules.MAX_ROLLS:
+        if self.roll_number >= GeneralaRules.MAX_ROLLS:
             raise Exception("No rolls left")
         self.held = held if held is not None else []
         self.dice = GeneralaRules.roll_dice(self.held)


### PR DESCRIPTION
## Summary
- ensure roll limit uses `>=` instead of `>` to correctly enforce 3 rolls max

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416fc5eaa88324a3e0f8b1107be27e