### PR TITLE
Add roll limit test for Generala

### DIFF
--- a/src/generala.py
+++ b/src/generala.py
@@ -125,7 +125,7 @@ class GeneralaGame:
         self.roll_number = 1
 
     def roll(self, held: Optional[List[int]] = None):
-        if self.roll_number > GeneralaRules.MAX_ROLLS:
+        if self.roll_number >= GeneralaRules.MAX_ROLLS:
             raise Exception("No rolls left")
         self.held = held if held is not None else []
         self.dice = GeneralaRules.roll_dice(self.held)

--- a/tests/test_generala.py
+++ b/tests/test_generala.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.generala import GeneralaGame, GeneralaRules
+
+
+def test_roll_raises_when_max_rolls_reached():
+    game = GeneralaGame(["p1"])
+    game.start_turn()
+    # Roll until reaching the maximum allowed rolls
+    while game.roll_number < GeneralaRules.MAX_ROLLS:
+        game.roll()
+    assert game.roll_number == GeneralaRules.MAX_ROLLS
+    with pytest.raises(Exception):
+        game.roll()


### PR DESCRIPTION
## Summary
- ensure GeneralaGame.roll raises when no rolls left
- enforce limit check in `GeneralaGame.roll`
- add pytest for roll limit behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416fc16894832495749281305715f9